### PR TITLE
Do not fetch on weekend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,8 @@ export default () => {
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(fetchThunk())
+    if (status !== Status.Weekend && status !== Status.WaitUntillTenOClock)
+      dispatch(fetchThunk())
   }, [dispatch])
 
   switch (status) {


### PR DESCRIPTION
## 문제였던 부분

- 주말인 경우에서 그날의 데이터를 불러올려고 하면 키 에러가 납니다.
- 월요일 10시 전에 데이터를 불러오면 새로운 데이터 버전이 과거 데이터와 일치하게 됩니다.

_This is hotfix commit_