### PR TITLE
Use self.skipWaiting() instead reload page

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -45,16 +45,19 @@ const fileToCache = [...staticFiles, ...cacheByAgent]
 self.addEventListener('install', evt => {
   evt.waitUntil(
     caches
-      .open(CACHE_NAME)
-      .then(cache => cache.addAll(fileToCache))
-      .catch(evt => console.log(evt))
-  )
+	.open(CACHE_NAME)
+	.then(cache => cache.addAll(fileToCache))
+	.catch(evt => console.log(evt))
+	)
+  
   evt.waitUntil(
     caches
       .open(getCacheVersion())
       .then(cache => cache.add(API_URL))
       .catch(evt => console.log(evt))
   )
+  
+  self.skipWaiting()
 })
 
 self.addEventListener('fetch', evt => {

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -87,7 +87,6 @@ function registerValidSW(swUrl: string, config?: Config) {
                 config.onUpdate(registration);
               }
 
-              window.location.reload()
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a


### PR DESCRIPTION
_Refreshing the page isn't enough to let the new version take over._

https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#waiting