### PR TITLE
Remove reload page code

### DIFF
--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -87,7 +87,6 @@ function registerValidSW(swUrl: string, config?: Config) {
                 config.onUpdate(registration);
               }
 
-              window.location.reload()
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a


### PR DESCRIPTION
Refreshing the page isn't enough to let the new service worker.

It could be replace to `self.skipWaiting()`, but I Postpone use this.

https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#waiting