### PR TITLE
Fix API version schedule

### DIFF
--- a/public/service-worker.ts
+++ b/public/service-worker.ts
@@ -1,17 +1,36 @@
 /// <reference path="../src/@types/service-worker" />
 // Hack: Import type for editor
 
-const getCacheVersion = () =>
+const getCacheVersion = (date: Date) =>
   `api_${(() => {
-    const DATE = new Date()
-    const weekday = Math.floor(DATE.getDate() / 7)
-    const dayOfWeek = DATE.getDay()
+    const weekday = Math.floor(date.getDate() / 7)
+    const dayOfWeek = date.getDay()
 
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6
-    const notYet = dayOfWeek === 1 && DATE.getHours() < 10
+    const notYet = dayOfWeek === 1 && date.getHours() < 10
+
+    if (weekday === 0 && (isWeekend || notYet)) return 4
 
     return isWeekend || notYet ? weekday - 1 : weekday
   })()}`
+
+const cases = [
+  { date: `2020-11-01`, expect: 'api_4' },
+  { date: `2020-11-02T08:00`, expect: 'api_4' },
+  { date: `2020-11-02T10:00`, expect: 'api_0' },
+  { date: `2020-11-07`, expect: 'api_0' },
+  { date: `2020-11-08`, expect: 'api_0' },
+  { date: `2020-11-09T08:00`, expect: 'api_0' },
+  { date: `2020-11-09T10:00`, expect: 'api_1' }
+]
+
+for (const { date, expect } of cases) {
+  const output = getCacheVersion(new Date(date))
+  console.assert(
+    output === expect,
+    `${date} should return ${expect} instead of ${output}.`
+  )
+}
 
 const CACHE_NAME = 'cache_v3'
 
@@ -54,14 +73,14 @@ self.addEventListener('install', evt => {
   evt.waitUntil(
     Promise.all([
       addCache(CACHE_NAME, fileToCache),
-      addCache(getCacheVersion(), API_URL)
+      addCache(getCacheVersion(new Date()), API_URL)
     ])
   )
 })
 
 self.addEventListener('fetch', evt => {
   if (evt.request.url === API_URL) {
-    const currentAPI = getCacheVersion()
+    const currentAPI = getCacheVersion(new Date())
     const cacheWhitelist = [CACHE_NAME, currentAPI]
 
     evt.waitUntil(
@@ -82,7 +101,7 @@ self.addEventListener('fetch', evt => {
 })
 
 self.addEventListener('activate', evt => {
-  const cacheWhitelist = [CACHE_NAME, getCacheVersion()]
+  const cacheWhitelist = [CACHE_NAME, getCacheVersion(new Date())]
   evt.waitUntil(cleanOldCache(cacheWhitelist))
 })
 

--- a/public/service-worker.ts
+++ b/public/service-worker.ts
@@ -5,7 +5,12 @@ const getCacheVersion = () =>
   `api_${(() => {
     const DATE = new Date()
     const weekday = Math.floor(DATE.getDate() / 7)
-    return weekday === 1 && DATE.getHours() < 10 ? weekday - 1 : weekday
+    const dayOfWeek = DATE.getDay()
+
+    const isWeekend = dayOfWeek === 0 || dayOfWeek === 6
+    const notYet = dayOfWeek === 1 && DATE.getHours() < 10
+
+    return isWeekend || notYet ? weekday - 1 : weekday
   })()}`
 
 const CACHE_NAME = 'cache_v3'


### PR DESCRIPTION
2020년 11월 7일에 `api_1`을 반환해서 고칩니다. 11월 9일 10시 이후 `api_1` 로 바꾸는 게 맞습니다.
<img width="547" alt="Screen Shot 2020-11-07 at 11 34 22 PM" src="https://user-images.githubusercontent.com/5278201/98444603-f027a980-2155-11eb-97e2-e4c4836e5f0e.png">

첫주 주말의 경우 지난 달의 버전을 보여주도록 케이스를 추가했습니다.