### PR TITLE
Fix non-sync fetch event workflow

### DIFF
--- a/public/service-worker.ts
+++ b/public/service-worker.ts
@@ -77,24 +77,24 @@ self.addEventListener('install', evt => {
 })
 
 self.addEventListener('fetch', evt => {
-  if (evt.request.url === API_URL) {
-    const currentAPI = getCacheVersion(new Date())
-    const cacheWhitelist = [CACHE_NAME, currentAPI]
+  evt.respondWith(
+    (async () => {
+      if (evt.request.url === API_URL) {
+        const currentAPI = getCacheVersion(new Date())
+        const cacheWhitelist = [CACHE_NAME, currentAPI]
 
-    evt.waitUntil(
-      caches.has(currentAPI).then(cache => {
-        if (!cache) {
-          return Promise.all([
+        const isCached = await caches.has(currentAPI)
+        if (!isCached) {
+          await Promise.all([
             addCache(currentAPI, API_URL),
             cleanOldCache(cacheWhitelist)
           ])
         }
-      })
-    )
-  }
+      }
 
-  evt.respondWith(
-    caches.match(evt.request).then(res => res || fetch(evt.request))
+      const res = await caches.match(evt.request)
+      return res || fetch(evt.request)
+    })()
   )
 })
 


### PR DESCRIPTION
waitUntil은 다음 fetch 이벤트를 버퍼링 시킬 뿐 동기적으로 다음 라인 진행을 막지 않습니다.

> event.waitUntil()에 프라미스를 전달하면 프라미스가 해결될 때까지 함수 이벤트(fetch, push, sync 등)가 버퍼링됩니다.
>
> [활성화, 서비스 워커 수명 주기 - Web Fundamentals  |  Google Developers](https://developers.google.com/web/fundamentals/primers/service-workers/lifecycle#%ED%99%9C%EC%84%B1%ED%99%94_2)

이 이유로 캐시를 업데이트하기 전에 데이터를 보여주게 되는 걸로 파악했습니다. 전부 event.respondWith 안에 캐시 갱신을 하도록 변경했습니다.